### PR TITLE
lvis92_trainset_issue

### DIFF
--- a/matcher/data/lvis.py
+++ b/matcher/data/lvis.py
@@ -68,7 +68,7 @@ class DatasetLVIS(Dataset):
         with open(os.path.join(self.anno_path, 'lvis_val.pkl'), 'rb') as f:
             val_anno = pickle.load(f)
 
-        train_cat_ids = list(train_anno.keys())
+        train_cat_ids = [i for i in list(train_anno.keys()) if len(train_anno[i]) > self.shot]
         val_cat_ids = [i for i in list(val_anno.keys()) if len(val_anno[i]) > self.shot]
 
         trn_nclass = len(train_cat_ids)


### PR DESCRIPTION
Fixes #38

Added a check for ensuring each class within the trainset is composed of at least nshot images, otherwise the load_frame function loops indefinitely

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aim-uofa/Matcher/pull/39?shareId=fbc8187f-9308-4041-a3bc-e8d33880e252).